### PR TITLE
ci(codeql): JS/TS-only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main, "**" ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: "0 3 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (CodeQL)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ "javascript-typescript" ]  # TS covers JS
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none                 # no build step for JS/TS
+          queries: security-and-quality
+      - uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,11 +2,11 @@ name: CodeQL
 
 on:
   push:
-    branches: [ main, "**" ]
+    branches: [main, '**']
   pull_request:
-    branches: [ main ]
+    branches: [main]
   schedule:
-    - cron: "0 3 * * 1"
+    - cron: '0 3 * * 1'
 
 jobs:
   analyze:
@@ -19,12 +19,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ "javascript-typescript" ]  # TS covers JS
+        language: ['javascript-typescript']
     steps:
       - uses: actions/checkout@v4
       - uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          build-mode: none                 # no build step for JS/TS
+          build-mode: none
           queries: security-and-quality
       - uses: github/codeql-action/analyze@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "vafmp-navigator",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
         "@react-native-async-storage/async-storage": "2.1.2",


### PR DESCRIPTION
Limit CodeQL to javascript-typescript to avoid cpp autobuild errors.